### PR TITLE
[Bug] Fixed Input mapping breaking

### DIFF
--- a/Assets/Scripts/InputAction/InputManager.cs
+++ b/Assets/Scripts/InputAction/InputManager.cs
@@ -19,6 +19,10 @@ public class InputManager : MonoBehaviour
         else
         {
             Instance = this;
+        }
+
+        if (Input == null)
+        {
             Input = new PlayerControls();
         }
     }


### PR DESCRIPTION
Static input reference was being replaced when Singleton was not started. 
Kept separate check to keep Original Input