### PR TITLE
Light fix animation and cat rejection speed

### DIFF
--- a/Assets/Animation/Cat.controller
+++ b/Assets/Animation/Cat.controller
@@ -14,7 +14,7 @@ AnimatorStateMachine:
     m_Position: {x: 30, y: 160, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -3597095435532523840}
-    m_Position: {x: 30, y: 210, z: 0}
+    m_Position: {x: 30, y: 240, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
@@ -61,7 +61,8 @@ AnimatorState:
   m_Name: CatReject
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions: []
+  m_Transitions:
+  - {fileID: 3758579673336001204}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -99,3 +100,25 @@ AnimatorController:
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
     m_Controller: {fileID: 9100000}
+--- !u!1101 &3758579673336001204
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -4466035237054626200}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 1
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1

--- a/Assets/Prefabs/Cat.prefab
+++ b/Assets/Prefabs/Cat.prefab
@@ -252,7 +252,7 @@ MonoBehaviour:
   _thoughtBubble: {fileID: 328679437897280706}
   _yarnTag: {fileID: 11400000, guid: a1d0c64b2d711b1408fdeb64edc363fb, type: 2}
   _minSize: 0.6
-  _minSqrVelocityRejection: 1
+  _minSqrVelocityRejection: 5
   OnCatScored:
     m_PersistentCalls:
       m_Calls: []


### PR DESCRIPTION
Fixes:
* Rejection animation should now play correctly (can now play after the first rejection),
* Cat's minimum velocity rejection value raised to 5 (suitable but can be changed later with additional playtesting).