### PR TITLE
Add guard before CheckTarget

### DIFF
--- a/Assets/Scripts/UI/OffScreenIndicator.cs
+++ b/Assets/Scripts/UI/OffScreenIndicator.cs
@@ -40,7 +40,7 @@ public class OffScreenIndicator : MonoBehaviour
     // Update is called once per frame
     private void LateUpdate()
     {
-        CheckTarget();
+        if(_target && _indicatorUI) CheckTarget();
     }
     #endregion
     


### PR DESCRIPTION
CheckTarget should only run if there is a target and indicatorUI. Fixes error in console for In-Game scene.