### PR TITLE
Change Yarn combine mass

### DIFF
--- a/Assets/Prefabs/Yarn.prefab
+++ b/Assets/Prefabs/Yarn.prefab
@@ -285,9 +285,9 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
   _massMultiplier: 1
-  _massCap: 5
+  _massCap: 1
   _scaleMultiplier: 1
-  _scaleCap: 5
+  _scaleCap: 2.5
   YarnCombineSound: Play_Yarn_Combine
 --- !u!114 &-1940726632899412579
 MonoBehaviour:

--- a/Assets/Scripts/Ball/BallCombine.cs
+++ b/Assets/Scripts/Ball/BallCombine.cs
@@ -53,9 +53,9 @@ public class BallCombine : MonoBehaviour
 
             Vector3 combinedScale = transform.localScale + hitBall.transform.localScale * _scaleMultiplier;
             float combinedMass = _rigidBody.mass + collision.rigidbody.mass * _massMultiplier;
-            
 
-            if (transform.localScale.x >= _scaleVectorCap.x * 0.99f || _rigidBody.mass >= _massCap)
+
+            if (transform.localScale.x >= _scaleVectorCap.x * 0.99f)// || _rigidBody.mass >= _massCap)
             {
                 return;            
             }
@@ -66,7 +66,7 @@ public class BallCombine : MonoBehaviour
             transform.localScale = Vector3.Min(combinedScale, _scaleVectorCap);
             _rigidBody.mass = Mathf.Min(combinedMass, _massCap);
 
-            if(transform.localScale == _scaleVectorCap || _rigidBody.mass == _massCap)
+            if (transform.localScale == _scaleVectorCap)// || _rigidBody.mass == _massCap)
             {
                 OnMaxSize.Invoke();
             }


### PR DESCRIPTION
I ended up removing the code that checks if the mass on the yarn ball reaches the mass capacity of the ball. The mass capacity of the ball is currently set to 1 to prevent it from being to difficult to move.