### PR TITLE
Added Event hook for Input device changes

### DIFF
--- a/Assets/Prefabs/Game Manager.prefab
+++ b/Assets/Prefabs/Game Manager.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 3745909187391131162}
   - component: {fileID: 3745909187391131161}
   - component: {fileID: 6293817618361023912}
+  - component: {fileID: 4721435269573690958}
   m_Layer: 0
   m_Name: Game Manager
   m_TagString: Untagged
@@ -47,7 +48,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _maxDuplicateSpawn: 1
   _firstSpawnIndex: -1
-  targetScore: 0
+  targetScore: 45
   timePerSecond: 1
   mainMenuSceneName: Main Menu
   _SpawnPoint: {fileID: 11400000, guid: 77dade94725caf542a48e1bc05c44481, type: 2}
@@ -86,3 +87,112 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Default: 1
+  OnChangeControl:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &4721435269573690958
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3745909187391131160}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Actions: {fileID: -944628639613478452, guid: 6b8baf6633c7d8c4ab79716791cdc010, type: 3}
+  m_NotificationBehavior: 2
+  m_UIInputModule: {fileID: 0}
+  m_DeviceLostEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_DeviceRegainedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ControlsChangedEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6293817618361023912}
+        m_TargetAssemblyTypeName: InputManager, Scripts
+        m_MethodName: OnControlsChanged
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  m_ActionEvents:
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 351f2ccd-1f9f-44bf-9bec-d62ac5c5f408
+    m_ActionName: Player/Look[/XInputControllerWindows/leftStick,/Keyboard/w,/Keyboard/upArrow,/Keyboard/s,/Keyboard/downArrow,/Keyboard/a,/Keyboard/leftArrow,/Keyboard/d,/Keyboard/rightArrow]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 6b444451-8a00-4d00-a97e-f47457f736a8
+    m_ActionName: Player/Move[/XInputControllerWindows/rightStick,/Mouse/delta]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 6c2ab1b8-8984-453a-af3d-a3c78ae1679a
+    m_ActionName: Player/Fire[/XInputControllerWindows/rightTrigger,/Mouse/leftButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: ed91d019-b2bf-4f73-ad5f-d14ebc816f74
+    m_ActionName: Player/Menu[/Keyboard/escape,/XInputControllerWindows/start]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 6b5aa7c1-d0bf-4178-aee0-9e525272a76f
+    m_ActionName: Player/Focus[/Keyboard/e,/XInputControllerWindows/buttonSouth]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 641df082-fdc6-494c-96b0-861f9fc6e057
+    m_ActionName: Player/Cancel[/Mouse/rightButton,/XInputControllerWindows/buttonEast]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: c95b2375-e6d9-4b88-9c4c-c5e76515df4b
+    m_ActionName: UI/Navigate[/XInputControllerWindows/leftStick/up,/XInputControllerWindows/rightStick/up,/XInputControllerWindows/leftStick/down,/XInputControllerWindows/rightStick/down,/XInputControllerWindows/leftStick/left,/XInputControllerWindows/rightStick/left,/XInputControllerWindows/leftStick/right,/XInputControllerWindows/rightStick/right,/XInputControllerWindows/dpad,/Keyboard/w,/Keyboard/upArrow,/Keyboard/s,/Keyboard/downArrow,/Keyboard/a,/Keyboard/leftArrow,/Keyboard/d,/Keyboard/rightArrow]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 7607c7b6-cd76-4816-beef-bd0341cfe950
+    m_ActionName: UI/Submit[/Keyboard/enter,/XInputControllerWindows/buttonSouth]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 15cef263-9014-4fd5-94d9-4e4a6234a6ef
+    m_ActionName: UI/Cancel[/Keyboard/escape,/XInputControllerWindows/buttonEast]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 32b35790-4ed0-4e9a-aa41-69ac6d629449
+    m_ActionName: UI/Point[/Mouse/position]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 3c7022bf-7922-4f7c-a998-c437916075ad
+    m_ActionName: UI/Click[/Mouse/leftButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 0489e84a-4833-4c40-bfae-cea84b696689
+    m_ActionName: UI/ScrollWheel[/Mouse/scroll]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: dad70c86-b58c-4b17-88ad-f5e53adf419e
+    m_ActionName: UI/MiddleClick[/Mouse/middleButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 44b200b1-1557-4083-816c-b22cbdf77ddf
+    m_ActionName: UI/RightClick[/Mouse/rightButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 24908448-c609-4bc3-a128-ea258674378a
+    m_ActionName: UI/TrackedDevicePosition
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 9caa3d8a-6b2f-4e8e-8bad-6ede561bd9be
+    m_ActionName: UI/TrackedDeviceOrientation
+  m_NeverAutoSwitchControlSchemes: 0
+  m_DefaultControlScheme: 
+  m_DefaultActionMap: Player
+  m_SplitScreenIndex: -1
+  m_Camera: {fileID: 0}

--- a/Assets/Scenes/TEST - Editor Only/Jyama/Dev/TestLevel.unity
+++ b/Assets/Scenes/TEST - Editor Only/Jyama/Dev/TestLevel.unity
@@ -638,14 +638,22 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 493177538320058705, guid: 03055bf8e2c5ceb46a63bb23fbd35593, type: 3}
-      propertyPath: m_RootOrder
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 667002868965942073, guid: 03055bf8e2c5ceb46a63bb23fbd35593, type: 3}
+    - target: {fileID: 42932480525824851, guid: 03055bf8e2c5ceb46a63bb23fbd35593, type: 3}
       propertyPath: m_RootOrder
       value: 6
       objectReference: {fileID: 0}
+    - target: {fileID: 389415586926962829, guid: 03055bf8e2c5ceb46a63bb23fbd35593, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 493177538320058705, guid: 03055bf8e2c5ceb46a63bb23fbd35593, type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 667002868965942073, guid: 03055bf8e2c5ceb46a63bb23fbd35593, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
     - target: {fileID: 1795133694425932128, guid: 03055bf8e2c5ceb46a63bb23fbd35593, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -670,6 +678,18 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2248657673728891461, guid: 03055bf8e2c5ceb46a63bb23fbd35593, type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 2526835410252589570, guid: 03055bf8e2c5ceb46a63bb23fbd35593, type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 3164191732384014232, guid: 03055bf8e2c5ceb46a63bb23fbd35593, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
     - target: {fileID: 3165477965104132715, guid: 03055bf8e2c5ceb46a63bb23fbd35593, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -693,10 +713,14 @@ PrefabInstance:
     - target: {fileID: 3165477965104132715, guid: 03055bf8e2c5ceb46a63bb23fbd35593, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7364637518565898920, guid: 03055bf8e2c5ceb46a63bb23fbd35593, type: 3}
+      propertyPath: m_RootOrder
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 7508694002176643449, guid: 03055bf8e2c5ceb46a63bb23fbd35593, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 7781372501394609602, guid: 03055bf8e2c5ceb46a63bb23fbd35593, type: 3}
       propertyPath: m_Pivot.x
@@ -1079,7 +1103,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 385420962}
-  m_LocalRotation: {x: -0.07119891, y: 0.9287514, z: -0.25221223, w: -0.26218435}
+  m_LocalRotation: {x: -0.071198925, y: 0.9287514, z: -0.25221223, w: -0.26218432}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -1651,7 +1675,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 672856500}
-  m_LocalRotation: {x: -0.06366047, y: 0.935594, z: -0.22550833, w: -0.264116}
+  m_LocalRotation: {x: -0.063660465, y: 0.935594, z: -0.22550838, w: -0.26411596}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -1849,6 +1873,34 @@ PrefabInstance:
     - target: {fileID: 3745909187391131162, guid: 9a77eb49f5bd97343a3415c62f7639be, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6293817618361023912, guid: 9a77eb49f5bd97343a3415c62f7639be, type: 3}
+      propertyPath: OnChangeControl.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6293817618361023912, guid: 9a77eb49f5bd97343a3415c62f7639be, type: 3}
+      propertyPath: OnChangeControl.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6293817618361023912, guid: 9a77eb49f5bd97343a3415c62f7639be, type: 3}
+      propertyPath: OnChangeControl.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 2059204215}
+    - target: {fileID: 6293817618361023912, guid: 9a77eb49f5bd97343a3415c62f7639be, type: 3}
+      propertyPath: OnChangeControl.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6293817618361023912, guid: 9a77eb49f5bd97343a3415c62f7639be, type: 3}
+      propertyPath: OnChangeControl.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Log
+      objectReference: {fileID: 0}
+    - target: {fileID: 6293817618361023912, guid: 9a77eb49f5bd97343a3415c62f7639be, type: 3}
+      propertyPath: OnChangeControl.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: TestSpace.TestManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 6293817618361023912, guid: 9a77eb49f5bd97343a3415c62f7639be, type: 3}
+      propertyPath: OnChangeControl.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9a77eb49f5bd97343a3415c62f7639be, type: 3}
@@ -3885,7 +3937,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1944066621}
-  m_LocalRotation: {x: -0.07119892, y: 0.9287514, z: -0.25221223, w: -0.26218435}
+  m_LocalRotation: {x: -0.0711989, y: 0.9287514, z: -0.25221223, w: -0.2621843}
   m_LocalPosition: {x: 6.275071, y: 8, z: 10.228563}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0

--- a/Assets/Scripts/InputAction/InputManager.cs
+++ b/Assets/Scripts/InputAction/InputManager.cs
@@ -13,6 +13,8 @@ public class InputManager : MonoBehaviour
     public static System.Action<string> OnChangeScheme;
     public UnityEvent<string> OnChangeControl;
 
+    public static string CurrentControlScheme { get; private set; }
+
     private static PlayerControls _input;
     public static PlayerControls Input { get => _input != null ? _input : (_input = new PlayerControls()); }
 
@@ -32,8 +34,10 @@ public class InputManager : MonoBehaviour
 
     public void OnControlsChanged(PlayerInput obj)
     {
-        OnChangeScheme?.Invoke(obj.currentControlScheme);
-        OnChangeControl.Invoke(obj.currentControlScheme);
+        CurrentControlScheme = obj.currentControlScheme;
+
+        OnChangeScheme?.Invoke(CurrentControlScheme);
+        OnChangeControl.Invoke(CurrentControlScheme);
     }
 
     private void OnEnable()

--- a/Assets/Scripts/InputAction/InputManager.cs
+++ b/Assets/Scripts/InputAction/InputManager.cs
@@ -2,12 +2,16 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.InputSystem;
+using UnityEngine.Events;
 
 public class InputManager : MonoBehaviour
 {
     public static InputManager Instance { get; private set; }
 
     public ControlMap Default;
+
+    public static System.Action<string> OnChangeScheme;
+    public UnityEvent<string> OnChangeControl;
 
     private static PlayerControls _input;
     public static PlayerControls Input { get => _input != null ? _input : (_input = new PlayerControls()); }
@@ -24,6 +28,12 @@ public class InputManager : MonoBehaviour
         }
 
         SwitchControls(Default);
+    }
+
+    public void OnControlsChanged(PlayerInput obj)
+    {
+        OnChangeScheme?.Invoke(obj.currentControlScheme);
+        OnChangeControl.Invoke(obj.currentControlScheme);
     }
 
     private void OnEnable()


### PR DESCRIPTION
Added Event hooks for Devices changes.
- Access via System.Action<string> on InputManager.OnChangeScheme 
- Or via UnityEvent<string> on GameManager > InputManager
- Added static CurrentControlScheme


Test Level: Assets/Scenes/TEST - Editor Only/Jyama/Dev/TestLevel.unity
Prints to log when new device is used. 
