### PR TITLE
Cat rejects non-favorite color

### DIFF
--- a/Assets/Prefabs/Cat.prefab
+++ b/Assets/Prefabs/Cat.prefab
@@ -166,24 +166,12 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  OnRejectBallSize:
+  OnReject:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 6213822171653081978}
         m_TargetAssemblyTypeName: CatAnimationPlay, Scripts
         m_MethodName: PlayRejectAnimation
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1029533692401839570}
-        m_TargetAssemblyTypeName: CatSounds, Scripts
-        m_MethodName: OnRejectBallSize
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -205,76 +193,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  OnRejectBallForce:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 6213822171653081978}
-        m_TargetAssemblyTypeName: CatAnimationPlay, Scripts
-        m_MethodName: PlayRejectAnimation
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 1029533692401839570}
         m_TargetAssemblyTypeName: CatSounds, Scripts
-        m_MethodName: OnRejectBallForce
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 7834553214962954387}
-        m_TargetAssemblyTypeName: AutoConnectSign, Scripts
-        m_MethodName: SignAngry
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-  OnRejectDamagedBall:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 6213822171653081978}
-        m_TargetAssemblyTypeName: CatAnimationPlay, Scripts
-        m_MethodName: PlayRejectAnimation
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1029533692401839570}
-        m_TargetAssemblyTypeName: CatSounds, Scripts
-        m_MethodName: OnRejectBallSize
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 7834553214962954387}
-        m_TargetAssemblyTypeName: AutoConnectSign, Scripts
-        m_MethodName: SignAngry
-        m_Mode: 1
+        m_MethodName: HandleRejectType
+        m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/Assets/Scripts/Audio/CatSounds.cs
+++ b/Assets/Scripts/Audio/CatSounds.cs
@@ -5,11 +5,12 @@ using UnityEngine;
 
 public class CatSounds : MonoBehaviour
 {
-    private string FavoriteYarnColorSound = "Play_FavoriteYarnColor";
-    private string DefualtScore = "Play_Cat_Purr";
-    private string HighScore = "Play_HighScore";
-    private string RejectBallSizeSound = "Play_CatRefusesYarn";
-    private string RejectBallForceSound = "Play_CatRefusesYarn";
+    private readonly string FavoriteYarnColorSound = "Play_FavoriteYarnColor";
+    private readonly string DefualtScore = "Play_Cat_Purr";
+    private readonly string HighScore = "Play_HighScore";
+    private readonly string RejectBallSizeSound = "Play_CatRefusesYarn";
+    private readonly string RejectBallForceSound = "Play_CatRefusesYarn";
+    private readonly string RejectDefault = "Play_CatRefusesYarn";
 
     [SerializeField] private int _highScore = 20;
     public void OnScoredEvent(ScoreData data)
@@ -25,6 +26,17 @@ public class CatSounds : MonoBehaviour
         else
         {
             DefaultScoreSound();
+        }
+    }
+
+    public void HandleRejectType(RejectType type)
+    {
+        switch (type)
+        {
+            case RejectType.Force: OnRejectBallForce(); break;
+            case RejectType.Size: OnRejectBallForce(); break;
+
+            default: AkSoundEngine.PostEvent(RejectDefault, gameObject); break;
         }
     }
 

--- a/Assets/Scripts/Cat/CatYarnInteraction.cs
+++ b/Assets/Scripts/Cat/CatYarnInteraction.cs
@@ -50,7 +50,7 @@ public class CatYarnInteraction : MonoBehaviour
         {
             ColorController colorHit = collision.gameObject.GetComponent<ColorController>();
 
-            if(_rejectNonFavoriteColor && colorHit.Color != FavoriteColor)
+            if(_rejectOffColor && colorHit.Color != FavoriteColor)
             {
                 OnReject.Invoke(RejectType.Color);
                 return;

--- a/Assets/Scripts/Cat/CatYarnInteraction.cs
+++ b/Assets/Scripts/Cat/CatYarnInteraction.cs
@@ -22,6 +22,7 @@ public class CatYarnInteraction : MonoBehaviour
     private float _minSqrVelocityRejection = 4;
 
     [SerializeField] private bool _rejectDamagedBall = true;
+    [SerializeField, Tooltip("Reject Non-Favorite Colors")] private bool _rejectOffColor = true;
 
     public UnityEvent<float, bool> OnCatScored;
     public UnityEvent<RejectType> OnReject;
@@ -49,7 +50,7 @@ public class CatYarnInteraction : MonoBehaviour
         {
             ColorController colorHit = collision.gameObject.GetComponent<ColorController>();
 
-            if(colorHit.Color != FavoriteColor)
+            if(_rejectNonFavoriteColor && colorHit.Color != FavoriteColor)
             {
                 OnReject.Invoke(RejectType.Color);
                 return;


### PR DESCRIPTION
Added Reject Logic for non-favorite Color.
- Toggle on Cat prefab (Default = Reject non-favorite color)
- Cleaned up Reject logic to use Enum Reject Type instead of separate events. 
- Updated Cat sounds to use Enum Reject sound with default Cat rejection sound.